### PR TITLE
These need to be wrapped in a check for 10.14 as a version of 10.13 w…

### DIFF
--- a/Sources/Datadog/Core/Utils/ISO8601DateFormatter.swift
+++ b/Sources/Datadog/Core/Utils/ISO8601DateFormatter.swift
@@ -10,7 +10,7 @@ import Foundation
 extension ISO8601DateFormatter {
     static func `default`() -> ISO8601DateFormatter {
         let formatter = ISO8601DateFormatter()
-        if #available(OSX 10.13, *) {
+        if #available(OSX 10.14, *) {
             formatter.formatOptions.insert(.withFractionalSeconds)
         }
         return formatter

--- a/Sources/Datadog/Logs/LogOutputs/LogConsoleOutput.swift
+++ b/Sources/Datadog/Logs/LogOutputs/LogConsoleOutput.swift
@@ -22,7 +22,7 @@ internal struct LogConsoleOutput: LogOutput {
         let formatter = ISO8601DateFormatter.default()
         var options: ISO8601DateFormatter.Options = [.withFullTime]
 
-        if #available(OSX 10.13, *) {
+        if #available(OSX 10.14, *) {
             options.insert(.withFractionalSeconds)
         }
 

--- a/Tests/DatadogTests/Matchers/LogMatcher.swift
+++ b/Tests/DatadogTests/Matchers/LogMatcher.swift
@@ -11,7 +11,9 @@ import XCTest
 struct LogMatcher {
     private static let dateFormatter: ISO8601DateFormatter = {
         let formatter = ISO8601DateFormatter()
-        formatter.formatOptions.insert(.withFractionalSeconds)
+        if #available(OSX 10.14, *) {
+            formatter.formatOptions.insert(.withFractionalSeconds)
+        }
         return formatter
     }()
 


### PR DESCRIPTION
* `withFractionalSeconds` crashes on High Sierra (10.13) despite Apple docs stating that it is available on 10.13, so updating to 10.14.
